### PR TITLE
fix(Core/Boss Scripts): Naxxramas Boss Noth Loot Bug when killed in teleport phase

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
@@ -157,7 +157,6 @@ public:
 
         void JustDied(Unit*  killer) override
         {
-			me->NearTeleportTo(nothPosition.GetPositionX(), nothPosition.GetPositionY(), nothPosition.GetPositionZ(), nothPosition.GetOrientation(), true);
             BossAI::JustDied(killer);
             Talk(SAY_DEATH);
         }


### PR DESCRIPTION
when boss (noth) killed at low hp ,he teleport to top and die ! no one can loot him
IMG : https://ibb.co/3M5TDMV

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  when Boss killed him dead body teleport to start location


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->
Win 10 Vs 2017
Tested in game

##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->

just add this line 
			me->NearTeleportTo(nothPosition.GetPositionX(), nothPosition.GetPositionY(), nothPosition.GetPositionZ(), nothPosition.GetOrientation(), true);
before 
BossAI::JustDied(killer);
in Naxxramas/boss_noth.cpp


##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
